### PR TITLE
43 Move generic validation functions to validation-utils

### DIFF
--- a/bcgov_arches_common/src/bcgov_arches_common/validation-utils.ts
+++ b/bcgov_arches_common/src/bcgov_arches_common/validation-utils.ts
@@ -55,7 +55,7 @@ export function getFlattenResolver(
     ): Promise<{ errors: FlattenErrors }> => {
         // Run Zod first
         const base = (await baseZodResolver(values)) ?? {};
-        const rawErrors = (base.errors ?? {}) as FlattenErrors;
+        const rawErrors = { ...(base.errors ?? {}) } as FlattenErrors;
         const errors = collapseFieldNames(rawErrors);
         // Return just the errors bag; PrimeVue derives $form.*.invalid from this
         return { errors };


### PR DESCRIPTION
This PR moves the collapseFieldNames function from BCFMS to the new validation-utils.ts file. It also creates a reusable getFlattenResolver function which flattens and displays validation errors, which was previously defined in each step in BCFMS.