### PR TITLE
88 - Ensure index order contains all resource types

### DIFF
--- a/bcgov_arches_common/management/commands/bc_reindex_database.py
+++ b/bcgov_arches_common/management/commands/bc_reindex_database.py
@@ -109,6 +109,7 @@ class Command(BaseCommand):
         for key, value in resource_types_lookup.items():
             if key not in index_order:
                 ordered_resource_types.append(value[1])
+                index_order.append(key)
 
         self.delete_indexes(name=None)
         self.setup_indexes(name=None)


### PR DESCRIPTION
Adds any missing slugs to index_order to avoid index out of range issue.
closes: bcgov/bcgov-arches-common#88

NB - this should also be merged into `release/2.1.x`