### PR TITLE
Adjust tileserver URLs for all app patterns

### DIFF
--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/MapDropZoneWidget/MapDropZoneWidget.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/MapDropZoneWidget/MapDropZoneWidget.vue
@@ -68,9 +68,9 @@ const concatenatedAliasedNodeData = computed<GeoJSONFeatureCollectionValue>(
         <div
             style="
                 display: inline-block;
-                width: 75%;
-                max-height: 500px;
-                max-width: 750px;
+                width: var(--map-width, 75%);
+                max-height: var(--map-max-height, 500px);
+                max-width: var(--map-max-width, 750px);
                 vertical-align: top;
                 overflow: clip;
             ">

--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/SimpleMap.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/SimpleMap.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { fetchSystemMapData } from '@/bcgov_arches_common/widgets/SimpleMap/api.ts';
-import { computed, ref, toRefs, shallowRef, watchEffect } from 'vue';
+import { type SimpleMapConfiguration } from '@/bcgov_arches_common/widgets/SimpleMap/types.ts';
+import { computed, inject, ref, toRefs, shallowRef, watchEffect } from 'vue';
 
 import type { GeoJSONFeatureCollectionCardXNodeXWidgetData } from '@/bcgov_arches_common/datatypes/geojson-feature-collection/types.ts';
 import { VIEW } from '@/arches_component_lab/widgets/constants.ts';
@@ -23,6 +24,7 @@ const props = defineProps<{
 const { graphSlug, nodeAlias, mode, cardXNodeXWidgetData, aliasedNodeData } =
     toRefs(props);
 
+const simpleMapConfig = inject('simpleMapConfig', {} as SimpleMapConfiguration);
 // From GenericWidget
 const isLoading = computed(() => {
     return mapDataLoading.value || widgetConfigLoading.value;
@@ -82,5 +84,7 @@ watchEffect(async () => {
         :node-alias="nodeAlias"
         :map-data="mapData"
         :card-x-node-x-widget-data="resolvedCardXNodeXWidgetData"
-        :aliased-node-data="aliasedNodeData"></MapView>
+        :aliased-node-data="aliasedNodeData"
+        :mark-centroid="simpleMapConfig.showCentroidMarker">
+    </MapView>
 </template>

--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/components/SimpleMapView.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/components/SimpleMapView.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import maplibregl, { type Map as MapLibreMap } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+
 import {
     watch,
     onMounted,
@@ -19,6 +21,7 @@ import type { GeoJsonCardXNodeXWidgetData } from '@/bcgov_arches_common/widgets/
 import {
     buildLayersForFeature,
     removeLayersUsingSource,
+    getCentroidMarker,
 } from '@/bcgov_arches_common/widgets/SimpleMap/utils.ts';
 import type {
     MapData,
@@ -40,9 +43,16 @@ const props = defineProps<{
         | undefined;
     mapData: MapData | undefined | null;
     aliasedNodeData: GeoJSONFeatureCollectionValue | undefined;
+    markCentroid?: boolean;
 }>();
-const { graphSlug, nodeAlias, cardXNodeXWidgetData, mapData, aliasedNodeData } =
-    toRefs(props);
+const {
+    graphSlug,
+    nodeAlias,
+    cardXNodeXWidgetData,
+    mapData,
+    aliasedNodeData,
+    markCentroid,
+} = toRefs(props);
 
 const geometry = computed<Feature | undefined>(() => {
     return aliasedNodeData?.value?.node_value?.features?.[0];
@@ -66,6 +76,10 @@ const allGeometries = computed<FeatureCollection | undefined>(() => {
 // });
 
 const mapLoaded = ref(false);
+const centroidMarker = shallowRef<maplibregl.Marker | null>(null);
+
+const addedDetails = new Map<string, MapFileData>();
+const addedFeatureIds = new Set<string>();
 
 // const defaultCenter = ref<[number, number]>([-123.1207, 49.2827]); // Vancouver (lng, lat)
 const defaultCenter = computed<[number, number]>(() => {
@@ -154,12 +168,12 @@ function setupMap(): void {
         }
     });
 
-    // map.value.on('moveend', () => {
-    //     if (!map.value) return;
-    //     const c = map.value.getCenter();
-    //     center.value = [Number(c.lng.toFixed(5)), Number(c.lat.toFixed(5))];
-    //     zoom.value = Number(map.value.getZoom().toFixed(2));
-    // });
+    map.value.on('moveend', () => {
+        if (!map.value) return;
+        // const c = map.value.getCenter();
+        // center.value = [Number(c.lng.toFixed(5)), Number(c.lat.toFixed(5))];
+        zoom.value = Number(map.value.getZoom().toFixed(2));
+    });
 
     const onResize = () => {
         console.log('Resizing');
@@ -265,6 +279,17 @@ const updateMapGeometries = (
         );
     }
 
+    if (markCentroid.value) {
+        if (!centroidMarker.value) {
+            centroidMarker.value = getCentroidMarker(
+                mapCentre.value,
+                'Feature centroid',
+            );
+            centroidMarker.value.addTo(map.value);
+        } else {
+            centroidMarker.value.setLngLat(mapCentre.value);
+        }
+    }
     center.value = mapCentre.value;
     console.log('New centre value: ', center.value);
 };
@@ -284,38 +309,44 @@ watch(
 );
 
 watch(
-    () => aliasedNodeData?.value?.node_value,
-    () => {
-        if (
-            props.cardXNodeXWidgetData &&
-            mapData &&
-            aliasedNodeData?.value?.node_value?.features?.[0]
-        ) {
-            updateMapGeometries([], []);
-        }
-    },
-);
+    () => aliasedNodeData?.value,
+    (newVal) => {
+        if (!props.cardXNodeXWidgetData || !mapData.value || !newVal) return;
 
-watch(
-    // () => aliasedNodeData.value?.node_value?.features,
-    () => aliasedNodeData.value?.details,
-    (features, prevFeature) => {
-        const prevFeatureIds = prevFeature?.map((f) => f.id) ?? [];
-        const newFeatureIds = features?.map((f) => f.id) ?? [];
-        const featuresToAdd = features?.filter(
-            (feature) => !prevFeatureIds.includes(feature.id),
+        const newDetails = newVal.details ?? [];
+        const newDetailIds = new Set(
+            newDetails.map((d) => d.geometrySourceId as string),
         );
-        const featuresToRemove = prevFeature?.filter(
-            (feature) => !newFeatureIds.includes(feature.id),
+
+        const toAdd = newDetails.filter(
+            (d) => !addedDetails.has(d.geometrySourceId as string),
         );
-        console.log(featuresToAdd);
-        if (
-            ((featuresToAdd?.length ?? 0) || (featuresToRemove?.length ?? 0)) &&
-            map.value &&
-            aliasedNodeData.value?.node_value
-        ) {
-            console.log('Updating geometry from watch event');
-            updateMapGeometries(featuresToAdd ?? [], featuresToRemove ?? []);
+        const toRemove = [...addedDetails.values()].filter(
+            (d) => !newDetailIds.has(d.geometrySourceId as string),
+        );
+
+        toAdd.forEach((d) => {
+            addedDetails.set(d.geometrySourceId as string, d);
+            d.geometries.features.forEach((f: Feature) =>
+                addedFeatureIds.add(String(f.id)),
+            );
+        });
+        toRemove.forEach((d) => {
+            addedDetails.delete(d.geometrySourceId as string);
+            d.geometries.features.forEach((f) =>
+                addedFeatureIds.delete(String(f.id)),
+            );
+        });
+
+        if (toAdd.length || toRemove.length) {
+            updateMapGeometries(toAdd, toRemove);
+        } else {
+            const unaddedNodeFeatures = (
+                newVal.node_value?.features ?? []
+            ).filter((f) => f.id && !addedFeatureIds.has(String(f.id)));
+            if (unaddedNodeFeatures.length) {
+                updateMapGeometries([], []);
+            }
         }
     },
 );
@@ -328,7 +359,12 @@ watch(
         <div
             ref="mapEl"
             class="map"
-            style="min-height: 300px; max-height: 500px"></div>
+            style="
+                min-height: var(--map-height, 550px);
+                height: var(--map-height, 550px);
+                max-height: var(--map-max-height, 550px);
+                max-width: var(--map-max-width, 700px);
+            "></div>
         <div class="panel">
             <!--button @click="flyVancouver">Vancouver</button>
             <button @click="flyParis">Paris</button-->
@@ -340,3 +376,8 @@ watch(
         </div>
     </div>
 </template>
+<style>
+.map-wrap > .panel {
+    background-color: transparent;
+}
+</style>

--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/types.ts
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/types.ts
@@ -36,3 +36,7 @@ export type GeoJsonNodeConfigType = {
 export type GeoJsonCardXNodeXWidgetData = Omit<CardXNodeXWidgetData, 'node'> & {
     node: GeoJsonNode;
 };
+
+export type SimpleMapConfiguration = {
+    showCentroidMarker?: boolean;
+};

--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/utils.test.ts
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/utils.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Feature, FeatureCollection } from 'geojson';
+import type { GeoJsonCardXNodeXWidgetData } from './types';
+
+// Mock maplibre-gl before importing utils (which imports it at module level)
+vi.mock('maplibre-gl', () => {
+    const mockPopup = { setHTML: vi.fn().mockReturnThis() };
+    const mockMarker = {
+        setLngLat: vi.fn().mockReturnThis(),
+        setPopup: vi.fn().mockReturnThis(),
+    };
+    return {
+        default: {
+            Marker: vi.fn(() => mockMarker),
+            Popup: vi.fn(() => mockPopup),
+        },
+    };
+});
+
+import maplibregl from 'maplibre-gl';
+import {
+    buildLayersForFeature,
+    getCentroidMarker,
+    removeLayersUsingSource,
+} from './utils';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const pointFeature = (): Feature => ({
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [0, 0] },
+    properties: {},
+});
+
+const lineFeature = (): Feature => ({
+    type: 'Feature',
+    geometry: {
+        type: 'LineString',
+        coordinates: [
+            [0, 0],
+            [1, 1],
+        ],
+    },
+    properties: {},
+});
+
+const polygonFeature = (): Feature => ({
+    type: 'Feature',
+    geometry: {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 0],
+            ],
+        ],
+    },
+    properties: {},
+});
+
+const featureCollection = (features: Feature[]): FeatureCollection => ({
+    type: 'FeatureCollection',
+    features,
+});
+
+const sourceJson = (config = {}): GeoJsonCardXNodeXWidgetData =>
+    ({
+        node: { alias: 'test', isrequired: false, nodeid: 'n1', config },
+    }) as GeoJsonCardXNodeXWidgetData;
+
+// ---------------------------------------------------------------------------
+// buildLayersForFeature
+// ---------------------------------------------------------------------------
+
+describe('buildLayersForFeature', () => {
+    describe('geometry type detection', () => {
+        it('returns a circle layer for a Point feature', () => {
+            const layers = buildLayersForFeature(
+                'src-1',
+                pointFeature(),
+                sourceJson(),
+            );
+            expect(layers).toHaveLength(1);
+            expect(layers[0].type).toBe('circle');
+            expect(layers[0].id).toContain('point');
+        });
+
+        it('returns halo + line layers for a LineString feature', () => {
+            const layers = buildLayersForFeature(
+                'src-2',
+                lineFeature(),
+                sourceJson(),
+            );
+            expect(layers).toHaveLength(2);
+            const types = layers.map((l) => l.type);
+            expect(types).toEqual(['line', 'line']);
+            const ids = layers.map((l) => l.id);
+            expect(ids.some((id) => id.includes('halo'))).toBe(true);
+            expect(ids.some((id) => id.includes('line') && !id.includes('halo'))).toBe(true);
+        });
+
+        it('returns fill + outline layers for a Polygon feature', () => {
+            const layers = buildLayersForFeature(
+                'src-3',
+                polygonFeature(),
+                sourceJson(),
+            );
+            expect(layers).toHaveLength(2);
+            const types = layers.map((l) => l.type);
+            expect(types).toContain('fill');
+            expect(types).toContain('line');
+        });
+
+        it('returns a fallback line layer for unknown geometry types', () => {
+            const unknown: Feature = {
+                type: 'Feature',
+                geometry: { type: 'GeometryCollection', geometries: [] },
+                properties: {},
+            };
+            const layers = buildLayersForFeature('src-4', unknown, sourceJson());
+            expect(layers).toHaveLength(1);
+            expect(layers[0].id).toContain('fallback');
+        });
+
+        it('returns all relevant layers for a mixed FeatureCollection', () => {
+            const layers = buildLayersForFeature(
+                'src-5',
+                featureCollection([pointFeature(), lineFeature(), polygonFeature()]),
+                sourceJson(),
+            );
+            const types = layers.map((l) => l.type);
+            expect(types).toContain('circle');
+            expect(types).toContain('fill');
+            expect(types.filter((t) => t === 'line').length).toBeGreaterThanOrEqual(3);
+        });
+    });
+
+    describe('source assignment', () => {
+        it('assigns the provided id as the source on all layers', () => {
+            const id = 'my-source-id';
+            const layers = buildLayersForFeature(id, polygonFeature(), sourceJson());
+            layers.forEach((l) => {
+                expect((l as any).source).toBe(id);
+            });
+        });
+    });
+
+    describe('color and weight config', () => {
+        it('applies custom lineColor from config', () => {
+            const layers = buildLayersForFeature(
+                'src',
+                lineFeature(),
+                sourceJson({ lineColor: 'rgba(0,255,0,0.5)' }),
+            );
+            const linePaint = (layers.find((l) => !l.id.includes('halo')) as any)
+                ?.paint;
+            expect(linePaint['line-color']).toBe('rgb(0, 255, 0)');
+            expect(linePaint['line-opacity']).toBeCloseTo(0.5);
+        });
+
+        it('clamps negative weight to 0', () => {
+            const layers = buildLayersForFeature(
+                'src',
+                lineFeature(),
+                sourceJson({ weight: -10, haloWeight: -5 }),
+            );
+            const haloPaint = (layers.find((l) => l.id.includes('halo')) as any)
+                ?.paint;
+            expect(haloPaint['line-width']).toBe(0); // 0 + 0
+        });
+
+        it('uses default colors when config is empty', () => {
+            const layers = buildLayersForFeature(
+                'src',
+                pointFeature(),
+                sourceJson(),
+            );
+            const paint = (layers[0] as any).paint;
+            // default pointColor is 'rgba(255,122,0,0.73)' → rgb(255, 122, 0)
+            expect(paint['circle-color']).toBe('rgb(255, 122, 0)');
+        });
+
+        it('applies custom fillColor from config', () => {
+            const layers = buildLayersForFeature(
+                'src',
+                polygonFeature(),
+                sourceJson({ fillColor: '#ff0000' }),
+            );
+            const fill = (layers.find((l) => l.type === 'fill') as any)?.paint;
+            expect(fill['fill-color']).toBe('#ff0000');
+        });
+    });
+
+    describe('layer id naming', () => {
+        it('includes the source id in all layer ids', () => {
+            const layers = buildLayersForFeature(
+                'abc-123',
+                polygonFeature(),
+                sourceJson(),
+            );
+            layers.forEach((l) => {
+                expect(l.id).toContain('abc-123');
+            });
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getCentroidMarker
+// ---------------------------------------------------------------------------
+
+describe('getCentroidMarker', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns a Marker configured with the amber colour', () => {
+        getCentroidMarker([0, 0]);
+        expect(maplibregl.Marker).toHaveBeenCalledWith({ color: '#d97706' });
+    });
+
+    it('calls setLngLat with the provided coordinates', () => {
+        const marker = getCentroidMarker([-123, 49]);
+        expect(marker.setLngLat).toHaveBeenCalledWith([-123, 49]);
+    });
+
+    it('uses the default popup text when none is provided', () => {
+        getCentroidMarker([0, 0]);
+        const popupInstance = (maplibregl.Popup as any).mock.results[0].value;
+        expect(popupInstance.setHTML).toHaveBeenCalledWith(
+            expect.stringContaining('Feature centroid'),
+        );
+    });
+
+    it('uses a custom popup text when provided', () => {
+        getCentroidMarker([0, 0], 'My location');
+        const popupInstance = (maplibregl.Popup as any).mock.results[0].value;
+        expect(popupInstance.setHTML).toHaveBeenCalledWith(
+            expect.stringContaining('My location'),
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// removeLayersUsingSource
+// ---------------------------------------------------------------------------
+
+describe('removeLayersUsingSource', () => {
+    const makeMap = (layers: { id: string; source?: string }[]) => ({
+        getStyle: vi.fn(() => ({ layers })),
+        getLayer: vi.fn((id: string) => layers.find((l) => l.id === id)),
+        removeLayer: vi.fn(),
+        getSource: vi.fn((id: string) => (id === 'my-source' ? {} : undefined)),
+        removeSource: vi.fn(),
+    });
+
+    it('removes layers that reference the given source', () => {
+        const map = makeMap([
+            { id: 'layer-a', source: 'my-source' },
+            { id: 'layer-b', source: 'other-source' },
+        ]);
+        removeLayersUsingSource(map as any, 'my-source');
+        expect(map.removeLayer).toHaveBeenCalledWith('layer-a');
+        expect(map.removeLayer).not.toHaveBeenCalledWith('layer-b');
+    });
+
+    it('removes the source by default after removing layers', () => {
+        const map = makeMap([{ id: 'layer-a', source: 'my-source' }]);
+        removeLayersUsingSource(map as any, 'my-source');
+        expect(map.removeSource).toHaveBeenCalledWith('my-source');
+    });
+
+    it('does not remove the source when removeSource is false', () => {
+        const map = makeMap([{ id: 'layer-a', source: 'my-source' }]);
+        removeLayersUsingSource(map as any, 'my-source', false);
+        expect(map.removeSource).not.toHaveBeenCalled();
+    });
+
+    it('handles a map with no style gracefully', () => {
+        const map = {
+            getStyle: vi.fn(() => null),
+            removeLayer: vi.fn(),
+            getLayer: vi.fn(),
+            getSource: vi.fn(),
+            removeSource: vi.fn(),
+        };
+        expect(() =>
+            removeLayersUsingSource(map as any, 'my-source'),
+        ).not.toThrow();
+        expect(map.removeLayer).not.toHaveBeenCalled();
+    });
+
+    it('handles a style with no layers gracefully', () => {
+        const map = {
+            getStyle: vi.fn(() => ({})),
+            removeLayer: vi.fn(),
+            getLayer: vi.fn(),
+            getSource: vi.fn(),
+            removeSource: vi.fn(),
+        };
+        expect(() =>
+            removeLayersUsingSource(map as any, 'my-source'),
+        ).not.toThrow();
+    });
+
+    it('skips a layer if getLayer returns falsy', () => {
+        const map = {
+            getStyle: vi.fn(() => ({
+                layers: [{ id: 'layer-a', source: 'my-source' }],
+            })),
+            getLayer: vi.fn(() => undefined),
+            removeLayer: vi.fn(),
+            getSource: vi.fn(() => undefined),
+            removeSource: vi.fn(),
+        };
+        removeLayersUsingSource(map as any, 'my-source');
+        expect(map.removeLayer).not.toHaveBeenCalled();
+    });
+});

--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/utils.test.ts
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/utils.test.ts
@@ -100,7 +100,9 @@ describe('buildLayersForFeature', () => {
             expect(types).toEqual(['line', 'line']);
             const ids = layers.map((l) => l.id);
             expect(ids.some((id) => id.includes('halo'))).toBe(true);
-            expect(ids.some((id) => id.includes('line') && !id.includes('halo'))).toBe(true);
+            expect(
+                ids.some((id) => id.includes('line') && !id.includes('halo')),
+            ).toBe(true);
         });
 
         it('returns fill + outline layers for a Polygon feature', () => {
@@ -121,7 +123,11 @@ describe('buildLayersForFeature', () => {
                 geometry: { type: 'GeometryCollection', geometries: [] },
                 properties: {},
             };
-            const layers = buildLayersForFeature('src-4', unknown, sourceJson());
+            const layers = buildLayersForFeature(
+                'src-4',
+                unknown,
+                sourceJson(),
+            );
             expect(layers).toHaveLength(1);
             expect(layers[0].id).toContain('fallback');
         });
@@ -129,20 +135,30 @@ describe('buildLayersForFeature', () => {
         it('returns all relevant layers for a mixed FeatureCollection', () => {
             const layers = buildLayersForFeature(
                 'src-5',
-                featureCollection([pointFeature(), lineFeature(), polygonFeature()]),
+                featureCollection([
+                    pointFeature(),
+                    lineFeature(),
+                    polygonFeature(),
+                ]),
                 sourceJson(),
             );
             const types = layers.map((l) => l.type);
             expect(types).toContain('circle');
             expect(types).toContain('fill');
-            expect(types.filter((t) => t === 'line').length).toBeGreaterThanOrEqual(3);
+            expect(
+                types.filter((t) => t === 'line').length,
+            ).toBeGreaterThanOrEqual(3);
         });
     });
 
     describe('source assignment', () => {
         it('assigns the provided id as the source on all layers', () => {
             const id = 'my-source-id';
-            const layers = buildLayersForFeature(id, polygonFeature(), sourceJson());
+            const layers = buildLayersForFeature(
+                id,
+                polygonFeature(),
+                sourceJson(),
+            );
             layers.forEach((l) => {
                 expect((l as any).source).toBe(id);
             });
@@ -156,8 +172,9 @@ describe('buildLayersForFeature', () => {
                 lineFeature(),
                 sourceJson({ lineColor: 'rgba(0,255,0,0.5)' }),
             );
-            const linePaint = (layers.find((l) => !l.id.includes('halo')) as any)
-                ?.paint;
+            const linePaint = (
+                layers.find((l) => !l.id.includes('halo')) as any
+            )?.paint;
             expect(linePaint['line-color']).toBe('rgb(0, 255, 0)');
             expect(linePaint['line-opacity']).toBeCloseTo(0.5);
         });
@@ -265,7 +282,7 @@ describe('removeLayersUsingSource', () => {
         ]);
         removeLayersUsingSource(map as any, 'my-source');
         expect(map.removeLayer).toHaveBeenCalledWith('layer-a');
-        expect(map.removeLayer).not.toHaveBeenCalledWith('layer-b');
+        expect(map.removeLayer).toHaveBeenCalledTimes(1);
     });
 
     it('removes the source by default after removing layers', () => {
@@ -277,7 +294,7 @@ describe('removeLayersUsingSource', () => {
     it('does not remove the source when removeSource is false', () => {
         const map = makeMap([{ id: 'layer-a', source: 'my-source' }]);
         removeLayersUsingSource(map as any, 'my-source', false);
-        expect(map.removeSource).not.toHaveBeenCalled();
+        expect(map.removeSource.mock.calls).toHaveLength(0);
     });
 
     it('handles a map with no style gracefully', () => {
@@ -288,10 +305,9 @@ describe('removeLayersUsingSource', () => {
             getSource: vi.fn(),
             removeSource: vi.fn(),
         };
-        expect(() =>
-            removeLayersUsingSource(map as any, 'my-source'),
-        ).not.toThrow();
-        expect(map.removeLayer).not.toHaveBeenCalled();
+        // should not throw — test fails automatically if it does
+        removeLayersUsingSource(map as any, 'my-source');
+        expect(map.removeLayer.mock.calls).toHaveLength(0);
     });
 
     it('handles a style with no layers gracefully', () => {
@@ -302,9 +318,8 @@ describe('removeLayersUsingSource', () => {
             getSource: vi.fn(),
             removeSource: vi.fn(),
         };
-        expect(() =>
-            removeLayersUsingSource(map as any, 'my-source'),
-        ).not.toThrow();
+        // should not throw — test fails automatically if it does
+        removeLayersUsingSource(map as any, 'my-source');
     });
 
     it('skips a layer if getLayer returns falsy', () => {
@@ -318,6 +333,6 @@ describe('removeLayersUsingSource', () => {
             removeSource: vi.fn(),
         };
         removeLayersUsingSource(map as any, 'my-source');
-        expect(map.removeLayer).not.toHaveBeenCalled();
+        expect(map.removeLayer.mock.calls).toHaveLength(0);
     });
 });

--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/utils.ts
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/utils.ts
@@ -4,7 +4,8 @@ import type {
     GeoJsonCardXNodeXWidgetData,
     GeoJsonNodeConfigType,
 } from '@/bcgov_arches_common/widgets/SimpleMap/types.ts';
-import type { LayerSpecification } from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
+import type { LayerSpecification, LngLatLike } from 'maplibre-gl';
 
 type ParsedColor = { color: string; opacity: number };
 
@@ -202,6 +203,15 @@ export function buildLayersForFeature(
     }
 
     return layers;
+}
+
+export function getCentroidMarker(
+    mapCentre: LngLatLike,
+    popupText: string = 'Feature centroid',
+) {
+    return new maplibregl.Marker({ color: '#d97706' })
+        .setLngLat(mapCentre)
+        .setPopup(new maplibregl.Popup().setHTML(`<b>${popupText}</b>`));
 }
 
 export function removeLayersUsingSource(

--- a/bcgov_arches_common/views/api/map.py
+++ b/bcgov_arches_common/views/api/map.py
@@ -17,10 +17,15 @@ class MapDataAPI(View):
         map_sources = list(models.MapSource.objects.all())
         for map_source in map_sources:
             if "tiles" in map_source.source:
+                should_add_prefix = not settings.PUBLIC_SERVER_ADDRESS.rstrip(
+                    "/"
+                ).endswith(prefix)
                 if not map_source.source["tiles"][0].startswith("http"):
                     stripped_url = map_source.source["tiles"][0].replace(prefix, "")
-                    source = "{}{}".format(
-                        settings.PUBLIC_SERVER_ADDRESS.rstrip("/"), stripped_url
+                    source = "{}{}{}".format(
+                        settings.PUBLIC_SERVER_ADDRESS.rstrip("/"),
+                        prefix if should_add_prefix else "",
+                        stripped_url,
                     )
                     map_source.source["tiles"][0] = source
 

--- a/tests/views/api/test_map.py
+++ b/tests/views/api/test_map.py
@@ -1,0 +1,150 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase
+
+
+class MapDataAPITest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = MagicMock()
+
+    def _make_source(self, source_dict):
+        obj = MagicMock()
+        obj.source = source_dict
+        return obj
+
+    def _get(self, map_sources, settings_overrides=None):
+        defaults = {
+            "BCGOV_PROXY_PREFIX": "",
+            "FORCE_SCRIPT_NAME": "/bcap",
+            "PUBLIC_SERVER_ADDRESS": "https://example.com",
+            "DEFAULT_BOUNDS": {"type": "FeatureCollection", "features": []},
+        }
+        if settings_overrides:
+            defaults.update(settings_overrides)
+
+        request = self.factory.get("/api/map/")
+        request.user = self.user
+
+        with (
+            patch(
+                "bcgov_arches_common.views.api.map.settings",
+                **{k: v for k, v in defaults.items()},
+            ) as mock_settings,
+            patch(
+                "bcgov_arches_common.views.api.map.models.MapSource.objects.all",
+                return_value=map_sources,
+            ),
+            patch(
+                "bcgov_arches_common.views.api.map.user_can_read_map_layers",
+                return_value=["layer1"],
+            ),
+        ):
+            mock_settings.BCGOV_PROXY_PREFIX = defaults["BCGOV_PROXY_PREFIX"]
+            mock_settings.FORCE_SCRIPT_NAME = defaults["FORCE_SCRIPT_NAME"]
+            mock_settings.PUBLIC_SERVER_ADDRESS = defaults["PUBLIC_SERVER_ADDRESS"]
+            mock_settings.DEFAULT_BOUNDS = defaults["DEFAULT_BOUNDS"]
+
+            from bcgov_arches_common.views.api.map import MapDataAPI
+
+            view = MapDataAPI.as_view()
+            response = view(request)
+
+        return response, json.loads(response.content)
+
+    # ------------------------------------------------------------------ prefix
+    def test_prefix_from_bcgov_proxy_prefix(self):
+        """BCGOV_PROXY_PREFIX takes precedence over FORCE_SCRIPT_NAME."""
+        source = self._make_source({"tiles": ["/tiles/wms"]})
+        response, data = self._get(
+            [source],
+            {
+                "BCGOV_PROXY_PREFIX": "myprefix",
+                "FORCE_SCRIPT_NAME": "/fallback",
+                "PUBLIC_SERVER_ADDRESS": "https://example.com",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        # prefix is /myprefix; PUBLIC_SERVER_ADDRESS doesn't end with it → prepended
+        self.assertIn("/myprefix", source.source["tiles"][0])
+
+    def test_prefix_falls_back_to_force_script_name(self):
+        """When BCGOV_PROXY_PREFIX is empty, FORCE_SCRIPT_NAME is used."""
+        source = self._make_source({"tiles": ["/tiles/wms"]})
+        _, data = self._get(
+            [source],
+            {
+                "BCGOV_PROXY_PREFIX": "",
+                "FORCE_SCRIPT_NAME": "/bcap",
+                "PUBLIC_SERVER_ADDRESS": "https://example.com",
+            },
+        )
+        self.assertIn("/bcap", source.source["tiles"][0])
+
+    # ------------------------------------------------------- tile URL rewriting
+    def test_http_tile_url_is_not_rewritten(self):
+        """Absolute tile URLs (http/https) are left untouched."""
+        original = "https://external.tiles.example.com/wms"
+        source = self._make_source({"tiles": [original]})
+        self._get([source])
+        self.assertEqual(source.source["tiles"][0], original)
+
+    def test_non_http_tile_url_is_rewritten(self):
+        """Relative tile URL gets PUBLIC_SERVER_ADDRESS + prefix prepended."""
+        source = self._make_source({"tiles": ["/tiles/wms"]})
+        _, data = self._get(
+            [source],
+            {
+                "BCGOV_PROXY_PREFIX": "",
+                "FORCE_SCRIPT_NAME": "/bcap",
+                "PUBLIC_SERVER_ADDRESS": "https://example.com",
+            },
+        )
+        self.assertTrue(
+            source.source["tiles"][0].startswith("https://example.com"),
+            source.source["tiles"][0],
+        )
+
+    def test_prefix_not_duplicated_when_already_in_public_server_address(self):
+        """Prefix is not added twice when PUBLIC_SERVER_ADDRESS already ends with it."""
+        source = self._make_source({"tiles": ["/tiles/wms"]})
+        self._get(
+            [source],
+            {
+                "BCGOV_PROXY_PREFIX": "",
+                "FORCE_SCRIPT_NAME": "/bcap",
+                "PUBLIC_SERVER_ADDRESS": "https://example.com/bcap",
+            },
+        )
+        url = source.source["tiles"][0]
+        self.assertNotIn("/bcap/bcap", url, f"Prefix duplicated in: {url}")
+
+    def test_source_without_tiles_key_is_unchanged(self):
+        """Sources without a 'tiles' key are skipped entirely."""
+        source = self._make_source({"type": "geojson", "data": "/api/features"})
+        original = dict(source.source)
+        self._get([source])
+        self.assertEqual(source.source, original)
+
+    # ---------------------------------------------------- response structure
+    def test_response_contains_expected_keys(self):
+        """Response JSON always contains map_layers, map_sources, default_bounds."""
+        _, data = self._get([])
+        self.assertIn("map_layers", data)
+        self.assertIn("map_sources", data)
+        self.assertIn("default_bounds", data)
+
+    def test_response_status_200(self):
+        response, _ = self._get([])
+        self.assertEqual(response.status_code, 200)
+
+    def test_map_layers_from_permission_check(self):
+        """map_layers comes from user_can_read_map_layers result."""
+        _, data = self._get([])
+        self.assertEqual(data["map_layers"], ["layer1"])
+
+    def test_default_bounds_passed_through(self):
+        bounds = {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}
+        _, data = self._get([], {"DEFAULT_BOUNDS": bounds})
+        self.assertEqual(data["default_bounds"], bounds)

--- a/tests/views/api/test_map.py
+++ b/tests/views/api/test_map.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+from django.http import JsonResponse
 from django.test import RequestFactory, TestCase
 
 
@@ -13,6 +14,24 @@ class MapDataAPITest(TestCase):
         obj = MagicMock()
         obj.source = source_dict
         return obj
+
+    @staticmethod
+    def _fake_json_response(data):
+        """Replace Arches' JSONResponse with a plain Django JsonResponse.
+
+        MagicMock source objects cannot be serialized by Arches'
+        betterJSONSerializer.  We reconstruct a safe payload using only the
+        real `.source` dict that was set on each mock, which is what the tests
+        actually care about.
+        """
+        safe = {
+            "map_layers": data.get("map_layers", []),
+            "map_sources": [
+                {"source": s.source} for s in (data.get("map_sources") or [])
+            ],
+            "default_bounds": data.get("default_bounds"),
+        }
+        return JsonResponse(safe)
 
     def _get(self, map_sources, settings_overrides=None):
         defaults = {
@@ -39,6 +58,10 @@ class MapDataAPITest(TestCase):
             patch(
                 "bcgov_arches_common.views.api.map.user_can_read_map_layers",
                 return_value=["layer1"],
+            ),
+            patch(
+                "bcgov_arches_common.views.api.map.JSONResponse",
+                side_effect=self._fake_json_response,
             ),
         ):
             mock_settings.BCGOV_PROXY_PREFIX = defaults["BCGOV_PROXY_PREFIX"]


### PR DESCRIPTION
- Adjust tileserver URLs for all app patterns
   - Check to see if PUBLIC_SERVER_ADDRESS ends with the prefix and adjust accordingly.
- Fixes to SimpleMap widget:
   - Make the height & width of the map configurable using CSS variables
   - Add missing maplibre import to fix map layout and missing controls
   - Updates to support optional Centroid marker
   - Fix geometries being added multiple times in MapDropZoneWIdget
   - Fix issue where centre value not being updated when geometry added
  