### PR TITLE
1353 - Don't escape nodes that have HTML values. Allow template override

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -63,6 +63,7 @@ runs:
 
     - name: Check frontend formatting with prettier
       run: |
+        npx prettier --version
         npm run prettier:check
       shell: bash
 

--- a/bcgov_arches_common/functions/abstract_primary_descriptors.py
+++ b/bcgov_arches_common/functions/abstract_primary_descriptors.py
@@ -7,10 +7,13 @@ from arches.app.functions.primary_descriptors import (
 
 
 class AbstractPrimaryDescriptors(CoreDescriptorsFunction):
+    _template = "<div class='bc-popup-entry'><div class='bc-popup-label'>%s</div><div class='bc-popup-value'>%s</div></div>"
     _graph_slug = ""
     _name_node_aliases = []
     _card_node_aliases = []
     _popup_node_aliases = []
+
+    _html_nodes = []
 
     _datatype_factory = DataTypeFactory()
 
@@ -31,6 +34,15 @@ class AbstractPrimaryDescriptors(CoreDescriptorsFunction):
                         node.datatype
                     )
                 )
+
+        # Get nodes that have HTML representations
+        all_nodes = set(AbstractPrimaryDescriptors._nodes.values())
+        cnws = (
+            models.CardXNodeXWidget.objects.filter(node__in=all_nodes)
+            .filter(widget__name="rich-text-widget")
+            .all()
+        )
+        AbstractPrimaryDescriptors._html_nodes = [cnw.node.alias for cnw in cnws]
 
         AbstractPrimaryDescriptors._initialized = True
 
@@ -72,12 +84,14 @@ class AbstractPrimaryDescriptors(CoreDescriptorsFunction):
                         AbstractPrimaryDescriptors._nodes[node_alias].name,
                         value,
                         config,
+                        node_alias in AbstractPrimaryDescriptors._html_nodes,
                     )
                 display_values.append(
                     AbstractPrimaryDescriptors._format_value(
                         AbstractPrimaryDescriptors._nodes[node_alias].name,
                         value,
                         config,
+                        node_alias in AbstractPrimaryDescriptors._html_nodes,
                     )
                 )
         return connector.join(display_values)
@@ -139,18 +153,22 @@ class AbstractPrimaryDescriptors(CoreDescriptorsFunction):
         )
 
     @staticmethod
-    def _format_value(name, value, config):
-        if isinstance(value, list):
-            value = set([html.escape(str(v)) for v in value if v != ""])
-            if "" in value:
-                value.remove("")
-            value = ", ".join(sorted(value))
+    def _format_value(name, value, config, is_html=False):
+        def escape_value(val):
+            if not val:
+                return val
+            return html.escape(str(val)) if not is_html else str(val)
 
         if value is None:
             return ""
-        elif config["show_name"]:
-            return (
-                "<div class='bc-popup-entry'><div class='bc-popup-label'>%s</div><div class='bc-popup-value'>%s</div></div>"
-                % (html.escape(name), html.escape(str(value)))
-            )
+        elif isinstance(value, list):
+            value = set([escape_value(v) for v in value if v != ""])
+            if "" in value:
+                value.remove("")
+            value = ", ".join(sorted(value))
+        else:
+            value = escape_value(value)
+
+        if config["show_name"]:
+            return AbstractPrimaryDescriptors._template % (html.escape(name), value)
         return value

--- a/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/components/SimpleMapView.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/widgets/SimpleMap/components/SimpleMapView.vue
@@ -39,8 +39,7 @@ const props = defineProps<{
     graphSlug: string;
     nodeAlias: string;
     cardXNodeXWidgetData:
-        | GeoJSONFeatureCollectionCardXNodeXWidgetData
-        | undefined;
+        GeoJSONFeatureCollectionCardXNodeXWidgetData | undefined;
     mapData: MapData | undefined | null;
     aliasedNodeData: GeoJSONFeatureCollectionValue | undefined;
     markCentroid?: boolean;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "gettext:extract": "vue-gettext-extract",
         "gettext:compile": "vue-gettext-compile",
         "prettier:check": "prettier bcgov_arches_common/src --check",
-        "prettier:fix": "prettier bcgov_arches_common/src --write",
+        "prettier:fix": "prettier --write",
+        "prettier:fix:all": "npm run prettier:fix bcgov_arches_common/src",
         "ts:check": "vue-tsc --noEmit",
         "ts:watch": "vue-tsc --watch --noEmit",
         "start": "cross-env NODE_OPTIONS=--max-old-space-size=2048 webpack serve --config ./webpack/webpack.config.dev.js",
@@ -44,7 +45,7 @@
         "@vue/eslint-config-prettier": "^10.2.0",
         "arches-dev-dependencies": "archesproject/arches-dev-dependencies#stable/8.0.8",
         "eslint-plugin-prettier": "^5.5.4",
-        "prettier": "^3.7.1",
+        "prettier": "3.9.3",
         "vite": "latest"
     },
     "nodeModulesPaths": {},

--- a/tests/functions/test_abstract_primary_descriptors.py
+++ b/tests/functions/test_abstract_primary_descriptors.py
@@ -42,13 +42,19 @@ class AbstractPrimaryDescriptorsTestCase(TestCase):
 
         return {"alias1": node1, "alias2": node2}
 
+    @patch(
+        "bcgov_arches_common.functions.abstract_primary_descriptors.models.CardXNodeXWidget"
+    )
     @patch("bcgov_arches_common.functions.abstract_primary_descriptors.models.Node")
     @patch("bcgov_arches_common.functions.abstract_primary_descriptors.DataTypeFactory")
-    def test_initialize_sets_nodes_and_datatypes(self, mock_factory, mock_node_model):
+    def test_initialize_sets_nodes_and_datatypes(
+        self, mock_factory, mock_node_model, mock_cnw
+    ):
         mock_factory.return_value.get_instance.return_value = self.mock_datatype
         mock_node_model.objects.filter.return_value.first.side_effect = (
             lambda: self.mock_nodes["alias1"]
         )
+        mock_cnw.objects.filter.return_value.filter.return_value.all.return_value = []
 
         descriptors = AbstractPrimaryDescriptors()
         descriptors.initialize()
@@ -158,3 +164,193 @@ class AbstractPrimaryDescriptorsTestCase(TestCase):
         self.assertEqual(result, "MapResult")
 
         self.assertTrue(mock_init.called)
+
+
+class FormatValueTestCase(TestCase):
+    """Tests for _format_value — covers the new is_html parameter, the moved
+    None check, the new escape_value helper, and the non-list else branch."""
+
+    def test_none_returns_empty_string(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", None, {"show_name": True}
+        )
+        self.assertEqual(result, "")
+
+    def test_none_returns_empty_string_without_show_name(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", None, {"show_name": False}
+        )
+        self.assertEqual(result, "")
+
+    def test_string_value_html_escaped_by_default(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", "<script>x</script>", {"show_name": False}
+        )
+        self.assertNotIn("<script>", result)
+        self.assertIn("&lt;script&gt;", result)
+
+    def test_string_value_not_escaped_when_is_html_true(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", "<b>bold</b>", {"show_name": False}, is_html=True
+        )
+        self.assertIn("<b>bold</b>", result)
+
+    def test_name_always_escaped_even_when_is_html_true(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "<b>Name</b>", "value", {"show_name": True}, is_html=True
+        )
+        self.assertIn("&lt;b&gt;Name&lt;/b&gt;", result)
+        self.assertNotIn("<b>Name</b>", result)
+
+    def test_show_name_false_returns_raw_escaped_value(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Node Name", "hello", {"show_name": False}
+        )
+        self.assertEqual(result, "hello")
+
+    def test_show_name_true_wraps_value_in_template(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Node Name", "hello", {"show_name": True}
+        )
+        self.assertIn("Node Name", result)
+        self.assertIn("hello", result)
+        self.assertIn("bc-popup-entry", result)
+
+    def test_list_values_sorted_and_deduplicated(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", ["b", "a", "b"], {"show_name": False}
+        )
+        self.assertEqual(result, "a, b")
+
+    def test_list_empty_strings_removed(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", ["a", "", "b"], {"show_name": False}
+        )
+        self.assertEqual(result, "a, b")
+
+    def test_list_html_content_escaped_by_default(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", ["<em>val</em>"], {"show_name": False}
+        )
+        self.assertNotIn("<em>", result)
+        self.assertIn("&lt;em&gt;", result)
+
+    def test_list_html_content_not_escaped_when_is_html_true(self):
+        result = AbstractPrimaryDescriptors._format_value(
+            "Name", ["<em>val</em>"], {"show_name": False}, is_html=True
+        )
+        self.assertIn("<em>val</em>", result)
+
+
+class HtmlNodesInitializeTestCase(TestCase):
+    """Tests for the _html_nodes population added to initialize."""
+
+    def setUp(self):
+        AbstractPrimaryDescriptors._graph_slug = "test_graph"
+        AbstractPrimaryDescriptors._name_node_aliases = ["alias1"]
+        AbstractPrimaryDescriptors._card_node_aliases = []
+        AbstractPrimaryDescriptors._popup_node_aliases = []
+        AbstractPrimaryDescriptors._nodes = {}
+        AbstractPrimaryDescriptors._datatypes = {}
+        AbstractPrimaryDescriptors._html_nodes = []
+        AbstractPrimaryDescriptors._initialized = False
+
+    @patch(
+        "bcgov_arches_common.functions.abstract_primary_descriptors.models.CardXNodeXWidget"
+    )
+    @patch("bcgov_arches_common.functions.abstract_primary_descriptors.models.Node")
+    @patch("bcgov_arches_common.functions.abstract_primary_descriptors.DataTypeFactory")
+    def test_rich_text_widget_nodes_added_to_html_nodes(
+        self, mock_factory, mock_node_model, mock_cnw
+    ):
+        mock_node = MagicMock()
+        mock_node.alias = "alias1"
+        mock_node.datatype = "string"
+        mock_factory.return_value.get_instance.return_value = MagicMock()
+        mock_node_model.objects.filter.return_value.first.return_value = mock_node
+
+        cnw = MagicMock()
+        cnw.node.alias = "alias1"
+        mock_cnw.objects.filter.return_value.filter.return_value.all.return_value = [
+            cnw
+        ]
+
+        AbstractPrimaryDescriptors().initialize()
+
+        self.assertIn("alias1", AbstractPrimaryDescriptors._html_nodes)
+
+    @patch(
+        "bcgov_arches_common.functions.abstract_primary_descriptors.models.CardXNodeXWidget"
+    )
+    @patch("bcgov_arches_common.functions.abstract_primary_descriptors.models.Node")
+    @patch("bcgov_arches_common.functions.abstract_primary_descriptors.DataTypeFactory")
+    def test_html_nodes_empty_when_no_rich_text_widgets(
+        self, mock_factory, mock_node_model, mock_cnw
+    ):
+        mock_node = MagicMock()
+        mock_node.alias = "alias1"
+        mock_node.datatype = "string"
+        mock_factory.return_value.get_instance.return_value = MagicMock()
+        mock_node_model.objects.filter.return_value.first.return_value = mock_node
+        mock_cnw.objects.filter.return_value.filter.return_value.all.return_value = []
+
+        AbstractPrimaryDescriptors().initialize()
+
+        self.assertEqual(AbstractPrimaryDescriptors._html_nodes, [])
+
+
+class GetValuesInOrderIsHtmlTestCase(TestCase):
+    """Tests that the is_html flag is correctly derived from _html_nodes and
+    forwarded to _format_value in get_values_in_order."""
+
+    def setUp(self):
+        node = MagicMock()
+        node.alias = "alias1"
+        node.name = "Node 1"
+        AbstractPrimaryDescriptors._nodes = {"alias1": node}
+        AbstractPrimaryDescriptors._datatypes = {}
+        self.config = {"first_only": False, "show_name": True}
+
+    @patch.object(AbstractPrimaryDescriptors, "_format_value")
+    @patch.object(AbstractPrimaryDescriptors, "_get_value_from_node")
+    def test_html_node_passes_is_html_true(self, mock_get_value, mock_format):
+        AbstractPrimaryDescriptors._html_nodes = ["alias1"]
+        mock_get_value.return_value = "a value"
+        mock_format.return_value = "formatted"
+
+        AbstractPrimaryDescriptors().get_values_in_order(
+            aliases=["alias1"], config=self.config, resource="res-id"
+        )
+
+        self.assertTrue(mock_format.call_args[0][3])
+
+    @patch.object(AbstractPrimaryDescriptors, "_format_value")
+    @patch.object(AbstractPrimaryDescriptors, "_get_value_from_node")
+    def test_non_html_node_passes_is_html_false(self, mock_get_value, mock_format):
+        AbstractPrimaryDescriptors._html_nodes = []
+        mock_get_value.return_value = "a value"
+        mock_format.return_value = "formatted"
+
+        AbstractPrimaryDescriptors().get_values_in_order(
+            aliases=["alias1"], config=self.config, resource="res-id"
+        )
+
+        self.assertFalse(mock_format.call_args[0][3])
+
+    @patch.object(AbstractPrimaryDescriptors, "_get_value_from_node")
+    def test_first_only_stops_after_first_matching_value(self, mock_get_value):
+        node2 = MagicMock()
+        node2.alias = "alias2"
+        node2.name = "Node 2"
+        AbstractPrimaryDescriptors._nodes["alias2"] = node2
+        AbstractPrimaryDescriptors._html_nodes = []
+        mock_get_value.side_effect = ["first value", "second value"]
+
+        result = AbstractPrimaryDescriptors().get_values_in_order(
+            aliases=["alias1", "alias2"],
+            config={"first_only": True, "show_name": False},
+            resource="res-id",
+        )
+
+        self.assertEqual(result, "first value")
+        mock_get_value.assert_called_once()


### PR DESCRIPTION
This should also be applied to release 2.0.x